### PR TITLE
Adding the Panicbot.app Validator - ShortTheFomo Operator to the XRPLF dUNL

### DIFF
--- a/data/unl-raw.yaml
+++ b/data/unl-raw.yaml
@@ -69,3 +69,5 @@ nodes:
     name: arrington-xrp-capital.blockdaemon.com
   - id: nHUcNC5ni7XjVYfCMe38Rm3KQaq27jw7wJpcUYdo4miWwpNePRTw
     name: cabbit.tech
+  - id: nHUkj4wj6iUK7RikWbwooJJDStLosoUTFYo91YUfYRvnpCgNTfAz
+    name: panicbot.app


### PR DESCRIPTION

The XRPL dUNL needs more quality operators, people who demonstrated to care deeply, be active participants and have a track record to be reliable. Luckily there are many XRPL validators who stepped up and make excellent candidates. 

Starting the progress to up the quality of operators i propose expanding the public good, XRP Ledger Foundation dUNL, by adding ShortTheFomo's Panicbot.app validator.

This Operator is a long time active contributor to the wider XRP Ledger community. By testing new amendments, building tools and services on https://threexrp.dev/ - running various systems and nodes. But also by participating in discussions around the XRPL.

The validator node is operational out of NL. The operator is located in Chile.

The TOML can be found here: https://panicbot.app/.well-known/xrp-ledger.toml