### PR TITLE
Remove: data443.com Add: tequ.dev

### DIFF
--- a/data/unl-raw.yaml
+++ b/data/unl-raw.yaml
@@ -5,8 +5,6 @@ nodes:
     name: bitso.com
   - id: nHUryiyDqEtyWVtFG24AAhaYjMf9FRLietbGzviF3piJsMm9qyDR
     name: www.bitrue.com
-  - id: nHUpJSKQTZdB1TDkbCREMuf8vEqFkk84BcvZDhsQsDufFDQVajam
-    name: data443.com
   - id: nHUfxETNHsA9reyYCVYwNztEbifMg6U9YUdcgVvzMwGNpphKSSf6
     name: xrpkuwait.com
   - id: nHUDpRzvY8fSRfQkmJMqjmVSaFmMEVxBNn2tNQy5VAhFJ6is6GFk
@@ -69,3 +67,5 @@ nodes:
     name: arrington-xrp-capital.blockdaemon.com
   - id: nHUcNC5ni7XjVYfCMe38Rm3KQaq27jw7wJpcUYdo4miWwpNePRTw
     name: cabbit.tech
+  - id: nHUxjxKPeErbN7pNk9UWA5Ee7ZPMtesSeRGJtmdqkTxe94tqM2YX
+    name: tequ.dev


### PR DESCRIPTION
Justification For Removal of data443.com

- [ ] Absent from community
- [ ] Absent from voting on amendments
- [ ] Absent from voting on fees (still on 10 XRP without justification of why)

In my opinion data443.com has not been a good community validator. While they have been reliable as far as uptime, they are almost completely absent from voting and this imo is more important than spinning up a server on aws. I also believe anyone who is still on the old fees without providing justification to why is actionable intelligence for review and removal. It tells me they are lazy and cannot be bothered to make one simple adjustment.

Justification for addition of tequ.dev

- [ ] Active Community Member
- [ ] Active voting on amendments
- [ ] Active voting on fees
- [ ] Actual Source Code Developer
- [ ] Reliable Validator
- [ ] Location in Japan

As of right now there are only a few validators on the UNL that have the capability to actually audit and review source code. Therefore if one of the decisions for a good validator is to make sure the code is reliable and not nefarious having more source code developers on the UNL makes sense to me.