### PR TITLE
Adding the tequ.dev Validator - @_tequ_ Operator to the XRPLF dUNL

### DIFF
--- a/data/unl-raw.yaml
+++ b/data/unl-raw.yaml
@@ -69,3 +69,5 @@ nodes:
     name: arrington-xrp-capital.blockdaemon.com
   - id: nHUcNC5ni7XjVYfCMe38Rm3KQaq27jw7wJpcUYdo4miWwpNePRTw
     name: cabbit.tech
+  - id: nHUxjxKPeErbN7pNk9UWA5Ee7ZPMtesSeRGJtmdqkTxe94tqM2YX
+    name: tequ.dev


### PR DESCRIPTION
A operator who not only contributes code changes but is geographically diverse from the rest of the operators @tequdev out of Japan.

I leave the validation that node is not run from a overlapping datacenter etc.

