### PR TITLE
Add girin.app validator (Girin Labs)

### DIFF
--- a/data/unl-raw.yaml
+++ b/data/unl-raw.yaml
@@ -69,3 +69,5 @@ nodes:
     name: squidrouter.com
   - id: nHUinfdpmtfXsMUnoSoBeZ93mTwDkPkA2gmCiQTyEi1c1Ybx6unE
     name: gen3labs.xyz
+  - id: nHBQWjEK6DKgvK19RQiUxsCn442hwUEKfUTSW4oofRh5MFvzvavG
+    name: girin.app


### PR DESCRIPTION
## Summary
This PR adds the `girin.app` validator, operated by Girin Labs, to the XRPLF UNL.
- **Validator public key:** `nHBQWjEK6DKgvK19RQiUxsCn442hwUEKfUTSW4oofRh5MFvzvavG`
- **Domain:** girin.app
- **Operator:** Girin Labs — an APAC-distributed team with primary hubs in Singapore and Seoul
- **Operation start:** 2026-03-27
- **rippled version:** 3.1.2
- **Agreement (xrpscan):** 99.47% (24h) / 99.63% (30d)
## Domain verification
`xrp-ledger.toml` is hosted with validator attestation:
- https://girin.app/.well-known/xrp-ledger.toml
```toml
[[VALIDATORS]]
public_key = "nHBQWjEK6DKgvK19RQiUxsCn442hwUEKfUTSW4oofRh5MFvzvavG"
attestation = "FC506F38B0570AFB8CCD5E9B6490DB6746D4389E3A978884D43C22B8B452CD41F4BF724EEFB5CFDDAE2B2CAF406413A3FDFA5B8BD3C5439538CB4946A6C07402"
network = "main"
owner_country = "SG"
server_country = "KR"
unl = "https://vl.ripple.com"
```
## Validator operations
- **Server:** AMD EPYC 12 vCPU / 32 GB RAM / 1 TB NVMe SSD (Netcup, Germany)
- **Architecture:** 2-tier — validator runs with `peer_private = 1` and connects only to a dedicated stock proxy node via `[ips_fixed]`. Validator IP is not exposed to the public network.
- **Security (validator):** SSH key authentication, password login disabled, root login restricted to key-only (`prohibit-password`), `ufw` firewall with peer port `51235` restricted to the proxy IP only, `fail2ban`, NTP-synced clock, `unattended-upgrades` for automatic security patches.
- **Security (proxy):** `ufw` firewall (22, 51235), `fail2ban`, NTP-synced clock, `unattended-upgrades`. SSH key authentication will be enforced as the next hardening step.
- **Monitoring:** Continuous monitoring of `server_state`, peer count, and amendment voting.
- **Update policy:** Target rippled updates within 48 hours of new releases.
## Diversity contribution
- **Geographic / Team structure:** Girin Labs is an **APAC-distributed team** with primary hubs in Singapore and Seoul, rather than a single-city operation. This reduces single-location risk and adds meaningful Asia-Pacific representation to a UNL currently concentrated in US/EU operators.
- **Jurisdictional:** Singapore / Korea dual jurisdictional footprint. Singapore is the APAC digital-asset regulatory hub (MAS); Korea is a major consumer and institutional finance market. The combination provides one of the most balanced APAC coverages available to the UNL.
- **Vertical:** First UNL candidate focused on **mobile-native XRPL developer tooling**, a Social-Login wallet with verifiable end-user metrics, **and** an XRPL-native Visa payment card.
## Ecosystem contributions
Girin Labs is a builder, not solely an infrastructure operator.
**Open-source developer tooling**
- **XRPLSwift** — iOS/Swift native XRPL library
- **xrpl4j / xrpl4j-android** — Java/Kotlin XRPL library
- **WalletKit / CryptoCore** — BIP39/BIP32/BIP44 (Swift) HD wallet primitives
- **WalletConnect integration** — XRPL examples and library
- GitHub: https://github.com/girin-app
**End-user infrastructure**
- **Girin Wallet** — Non-custodial XRPL wallet with Social Login (Google/Kakao), iOS/Android/Chrome Extension
  - **150K total users / 30K MAU** (monthly average for the previous year) — one of the few XRPL wallets backed by verifiable end-user metrics
- **Girin Card** — **XRPL-native Visa payment card**, launching mid-May 2026
  - Spending is authorized against the user's on-chain XRPL balance directly at authorization time
  - Direct use of **XRPL DEX and Path Payment** at authorization — users can spend with IOU tokens in addition to XRP, routed through XRPL's native order book
  - **Trust Line-based token payments** — extends XRPL's Trust Line model into the payment rail, preserving issuer-level compliance context
  - Visa's global merchant network gives XRPL assets **real-world spendability**
  - Productionizes XRPL primitives (IOU, Trust Line, Path Payment, DEX) as an end-user payment experience — first among UNL candidates
- **Doppler Finance** — Lending & Liquid Staking protocol on XRPL
## Network security & reliability contribution
Recognizing that network security is the XRPL Foundation's top-priority agenda, Girin Labs commits to active contributions beyond passive validator operation:
- **Bug detection & responsible disclosure** — Any rippled, amendment, or library issues surfaced through our production stack (mobile SDKs, Girin Wallet, Girin Card) will be reported to the XRPLF via responsible-disclosure channels as a first priority. Real user traffic from **150K Girin Wallet users and live Girin Card payment flows** generates production-grade edge cases difficult to reproduce on testnet or with synthetic data.
- **Amendment safety review** — Girin Labs engineering will run regression tests on each Fix Amendment and major protocol change in our own environment, and publish impact analysis on mobile SDK and card payment paths as public voting rationale.
- **Multi-layer validator hardening** — Proxy node with `peer_private = 1`, key-only SSH, scoped `ufw`, `fail2ban`, `unattended-upgrades`. Willing to participate in periodic security reviews and external penetration testing.
- **UNL quorum resilience** — APAC-based operation adds geographic safety margin for UNL quorum during broad US/EU regional outages.
## VC network enablement for XRPL builders
The long-term health of the XRPL ecosystem depends on whether builders can raise capital. Girin Labs commits to sharing its own investor network with XRPL builders as a **pass-through resource**:
- **Backer line (Girin Labs investors)**
  - **Ripple LP funds:** Tenity, Reforge
  - **Top-tier global VCs:** DCG (Digital Currency Group), Hashkey Capital, and others
  - Backed by the **XRP Ledger Japan & Korea Ecosystem Fund** (Ripple-backed)
- **Pass-through value** — Warm introductions from Girin Labs' VC/LP relationships to promising XRPL builders; builders selected through XRPL Korea programs (e.g., KFIP 2026) exposed to this investor network. "Builders build the product; Girin Labs bridges the capital" — establishing a **builder → investor pipeline** for the XRPL ecosystem.
## Post-inclusion commitments
- Public RPC endpoint for APAC-based XRPL developers
- Ongoing maintenance of XRPLSwift and xrpl4j across rippled version releases
- Public documentation of amendment voting rationale
- **Semi-annual security contribution report** — bug detection activity, amendment test results, infrastructure security posture
- APAC developer community programs via XRPL Korea (education, workshops, onboarding content); Singapore hub used to onboard builders across Southeast Asia
## Contact
- Operator: Girin Labs
- Validator domain: girin.app
- GitHub: https://github.com/girin-app
Happy to provide any additional information the UNL committee may need.